### PR TITLE
update google console verification tag

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ extra:
     issues: https://pegasys1.atlassian.net/secure/Dashboard.jspa?selectPageId=10000
   google:
     tag_manager: 'GTM-T5Q86JM'
-    site_verification: 'mB1S8j-y6oz3sfp36Q81dzMFyM7WEU5GHCImddGCqu8'
+    site_verification: 'za1cLzyS6LXDGO-pMzvfQdYTZ0Zc67uZtY0asA4YXZ0'
   search:
     language: 'en'
     tokenizer: '[\s]+'


### PR DESCRIPTION
update google console verification tag that was not pointing to the right domain.
